### PR TITLE
Instance attr

### DIFF
--- a/autodocsumm/__init__.py
+++ b/autodocsumm/__init__.py
@@ -618,7 +618,7 @@ class AutoSummDirective(AutodocDirective, Autosummary):
             real_name = documenter.fullname
             display_name = documenter.object_name
             if display_name is None:  # for instance attributes
-                display_name = real_name.split('.')[-1]
+                display_name = documenter.objpath[-1]
             if check_module and not documenter.check_module():
                 continue
 

--- a/autodocsumm/__init__.py
+++ b/autodocsumm/__init__.py
@@ -617,6 +617,8 @@ class AutoSummDirective(AutodocDirective, Autosummary):
             documenter.real_modname = documenter.get_real_modname()
             real_name = documenter.fullname
             display_name = documenter.object_name
+            if display_name is None:  # for instance attributes
+                display_name = real_name.split('.')[-1]
             if check_module and not documenter.check_module():
                 continue
 

--- a/tests/sphinx_supp/dummy.py
+++ b/tests/sphinx_supp/dummy.py
@@ -42,6 +42,10 @@ class Class_CallTest(object):
 class TestClass(object):
     """Class test for autosummary"""
 
+    def __init__(self):
+        #: This is an instance attribute
+        self.instance_attribute = 1
+
     def test_method(self):
         """Test if the method is included"""
         pass

--- a/tests/test_autodocsumm.py
+++ b/tests/test_autodocsumm.py
@@ -79,6 +79,9 @@ class TestAutosummaryDocumenter(unittest.TestCase):
     def test_class(self, app, status, warning):
         app.build()
         html = get_html(app, '/test_class.html')
+
+        self.assertIn('<span class="pre">instance_attribute</span>', html)
+
         self.assertIn('<span class="pre">test_method</span>', html)
         self.assertIn('<span class="pre">test_attr</span>', html)
 


### PR DESCRIPTION
Closes https://github.com/Chilipp/autodocsumm/issues/8

This PR adds the functionality to document instance attributes in the autosummary table. If the object cannot be imported (as it is the case for `InstanceAttributeDocumenter`), we use the `documenter.fullname` for the summary table.

@maeddlae: Can you confirm that this works for you?