### PR TITLE
remove warning by using override on add_directive for sphinx versions >= 1.8

### DIFF
--- a/autodocsumm/__init__.py
+++ b/autodocsumm/__init__.py
@@ -756,8 +756,12 @@ def setup(app):
                 app.add_autodocumenter(cls)
 
     # directives
-    app.add_directive('automodule', AutoSummDirective)
-    app.add_directive('autoclass', AutoSummDirective)
+    if sphinx.__version__ >= '1.8':
+        app.add_directive('automodule', AutoSummDirective, override=True)
+        app.add_directive('autoclass', AutoSummDirective, override=True)
+    else:
+        app.add_directive('automodule', AutoSummDirective)
+        app.add_directive('autoclass', AutoSummDirective)
 
     # group event
     app.add_event('autodocsumm-grouper')


### PR DESCRIPTION
closes #11 