### PR TITLE
change use of add_documenter

### DIFF
--- a/autodocsumm/__init__.py
+++ b/autodocsumm/__init__.py
@@ -749,11 +749,10 @@ def setup(app):
                 NoDataAttributeDocumenter]:
         if not issubclass(registry.get(cls.objtype), cls):
             try:
-                # we use add_documenter because this does not add a new
-                # directive
-                app.add_documenter(cls)
-            except AttributeError:
-                app.add_autodocumenter(cls)
+                # try with override
+                app.add_autodocumenter(cls, override=True)
+            except TypeError:
+                app.registry.add_documenter("auto" + cls.objtype, cls)
 
     # directives
     if sphinx.__version__ >= '1.8':


### PR DESCRIPTION
depends on override being added to sphinx https://github.com/sphinx-doc/sphinx/pull/6475

last fix I ran into for #11 see #12 for related use of `override`