### PR TITLE
Added options for summary only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,14 @@ env:
   - SPHINX_VERSION=1.7.*
   - SPHINX_VERSION=1.8.*
   - SPHINX_VERSION=2.0.*
+  - SPHINX_VERSION=2.1.*
   - SPHINX_VERSION=""
 matrix:
   exclude:
     - python: "2.7"
       env: SPHINX_VERSION=2.0.*
+    - python: "2.7"
+      env: SPHINX_VERSION=2.1.*
     - python: "3.7"
       env: SPHINX_VERSION=1.3.*
     - python: "3.7"

--- a/autodocsumm/__init__.py
+++ b/autodocsumm/__init__.py
@@ -34,7 +34,9 @@ else:
         getargspec, formatargspec, AutoDirective as AutodocDirective,
         AutoDirective as AutodocRegistry)
 
-if sphinx.__version__ >= '2.0':
+sphinx_version = list(map(float, re.findall(r'\d+', sphinx.__version__)[:3]))
+
+if sphinx_version >= [2, 0]:
     from sphinx.util import force_decode
 else:
     from sphinx.ext.autodoc import force_decode
@@ -54,9 +56,6 @@ if six.PY2:
 __version__ = '0.1.10'
 
 __author__ = "Philipp Sommer"
-
-
-sphinx_version = list(map(float, re.findall(r'\d+', sphinx.__version__)[:3]))
 
 logger = logging.getLogger(__name__)
 
@@ -426,11 +425,12 @@ class AutoSummDirective(AutodocDirective, Autosummary):
             except AttributeError:
                 lineno = None
             doc_class = get_documenters(self.env.app)[objtype]
+            args = (self.state, ) if sphinx_version >= [2, 1] else ()
             params = DocumenterBridge(
                 env, reporter,
                 process_documenter_options(doc_class, env.config,
                                            self.options),
-                lineno, self.state)
+                lineno, *args)
         documenter = doc_class(params, self.arguments[0])
         if hasattr(documenter, 'get_grouped_documenters'):
             self._autosummary_documenter = documenter
@@ -789,7 +789,7 @@ def setup(app):
                 app.add_autodocumenter(cls)
 
     # directives
-    if sphinx.__version__ >= '1.8':
+    if sphinx_version >= [1, 8]:
         app.add_directive('automodule', AutoSummDirective, override=True)
         app.add_directive('autoclass', AutoSummDirective, override=True)
     else:

--- a/autodocsumm/__init__.py
+++ b/autodocsumm/__init__.py
@@ -398,7 +398,7 @@ class AutoSummDirective(AutodocDirective, Autosummary):
 
     if sphinx_version < [1, 7]:
         _default_flags = AutodocDirective._default_flags.union(
-            {'autosummary'} + set(map('autosummary-{}'.format, member_options))
+            {'autosummary'} | set(map('autosummary-{}'.format, member_options))
             )
     else:
         AUTODOC_DEFAULT_OPTIONS.append('autosummary')

--- a/autodocsumm/__init__.py
+++ b/autodocsumm/__init__.py
@@ -60,6 +60,13 @@ sphinx_version = list(map(float, re.findall(r'\d+', sphinx.__version__)[:3]))
 
 logger = logging.getLogger(__name__)
 
+#: Options of the :class:`sphinx.ext.autodoc.ModuleDocumenter` that have an
+#: effect on the selection of members for the documentation
+member_options = {
+    'members', 'undoc-members', 'inherited-members', 'exlude-members',
+    'private-members', 'special-members', 'imported-members',
+    'ignore-module-all'}
+
 
 class AutosummaryDocumenter(object):
     """Abstract class for for extending Documenter methods
@@ -130,6 +137,12 @@ class AutosummaryDocumenter(object):
         if self.objpath:
             self.env.temp_data['autodoc:class'] = self.objpath[0]
 
+        # set the members from the autosummary member options
+        options_save = self.options.copy()
+        for option in member_options.intersection(self.options):
+            if getattr(self.options, 'autosummary-' + option):
+                self.options[option] = self.options['autosummary-' + option]
+
         want_all = all_members or self.options.inherited_members or \
             self.options.members is ALL
         # find out which members are documentable
@@ -174,6 +187,7 @@ class AutosummaryDocumenter(object):
                     e[0].object, section, self.object)
                 section = user_section or section
             documenters.setdefault(section, []).append(e)
+        self.options = options_save
         return documenters
 
 
@@ -191,8 +205,13 @@ class AutoSummModuleDocumenter(ModuleDocumenter, AutosummaryDocumenter):
 
     #: original option_spec from :class:`sphinx.ext.autodoc.ModuleDocumenter`
     #: but with additional autosummary boolean option
-    option_spec = ModuleDocumenter.option_spec
+    option_spec = ModuleDocumenter.option_spec.copy()
     option_spec['autosummary'] = bool_option
+
+    #: Add options for members for the autosummary
+    for _option in member_options.intersection(option_spec):
+        option_spec['autosummary-' + _option] = option_spec[_option]
+    del _option
 
     member_sections = OrderedDict([
         (ad.ClassDocumenter.member_order, 'Classes'),
@@ -222,8 +241,13 @@ class AutoSummClassDocumenter(ClassDocumenter, AutosummaryDocumenter):
 
     #: original option_spec from :class:`sphinx.ext.autodoc.ClassDocumenter`
     #: but with additional autosummary boolean option
-    option_spec = ClassDocumenter.option_spec
+    option_spec = ClassDocumenter.option_spec.copy()
     option_spec['autosummary'] = bool_option
+
+    #: Add options for members for the autosummary
+    for _option in member_options.intersection(option_spec):
+        option_spec['autosummary-' + _option] = option_spec[_option]
+    del _option
 
     member_sections = OrderedDict([
         (ad.ClassDocumenter.member_order, 'Classes'),
@@ -373,9 +397,13 @@ class AutoSummDirective(AutodocDirective, Autosummary):
     the specified module at the beginning of the module documentation."""
 
     if sphinx_version < [1, 7]:
-        _default_flags = AutodocDirective._default_flags.union({'autosummary'})
+        _default_flags = AutodocDirective._default_flags.union(
+            {'autosummary'} + set(map('autosummary-{}'.format, member_options))
+            )
     else:
         AUTODOC_DEFAULT_OPTIONS.append('autosummary')
+        AUTODOC_DEFAULT_OPTIONS.extend(
+            map('autosummary-{}'.format, member_options))
 
     @property
     def autosummary_documenter(self):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -60,7 +60,7 @@ source_suffix = '.rst'
 # The master toctree document.
 master_doc = 'index'
 
-autodoc_default_flags = ['show_inheritance', 'autosummary']
+autodoc_default_options = {'show_inheritance': True, 'autosummary': True}
 autoclass_content = 'both'
 autodata_content = 'call'
 
@@ -385,10 +385,10 @@ epub_exclude_files = ['search.html']
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    'sphinx': ('http://sphinx-doc.org/', None),
+    'sphinx': ('http://www.sphinx-doc.org/en/master/', None),
 }
 if six.PY3:
-    intersphinx_mapping['python'] = ('https://docs.python.org/3.4/', None)
+    intersphinx_mapping['python'] = ('https://docs.python.org/3.7/', None)
 else:
     intersphinx_mapping['python'] = ('https://docs.python.org/2.7/', None)
 

--- a/docs/conf_settings.rst
+++ b/docs/conf_settings.rst
@@ -1,13 +1,53 @@
-.. confvals:
+.. highlight:: rest
+
+Configuration of the sphinx extension
+=====================================
+
+The module provides 3 additional configuration values, one event and new
+flags for the autodoc directives :rst:dir:`autoclass` and :rst:dir:`automodule`.
+
+.. _autodoc-flags:
+
+Additional flags for autodoc directives
+---------------------------------------
+The most important new flag for the :rst:dir:`autoclass` and
+:rst:dir:`automodule` directives is the ``autosummary`` flag. If you want to
+have an automatically generated summary to your class or module, you have to
+add this flag, e.g. via::
+
+    .. autodoc:: MyClass
+        :autosummary:
+
+or in the :confval:`autodoc_default_options` configuration value of sphinx
+via
+
+.. code-block:: python
+
+    autodoc_default_options = {'autosummary': True}
+
+See also the :ref:`examples` section it's usage.
+
+The other additional flags let you control what should be in the autosummary
+table: these are
+
+- ``autosummary-private-members``
+- ``autosummary-undoc-members``
+- ``autosummary-inherited-members``
+- ``autosummary-special-members``
+- ``autosummary-exlude-members``
+- ``autosummary-imported-members``
+- ``autosummary-ignore-module-all``
+- ``autosummary-members``
+
+They are essentially the same as the options for :mod:`~sphinx.ext.autodoc`
+(i.e. ``private-members`` or ``members``, but they only affect the
+autosummary table (see the example in :ref:`summary-table-example`).
+
+
+.. _confvals:
 
 Configuration values and events
-===============================
-
-The module provides 3 additional configuration values and one event.
-Furthermore it provides the *autosummary* flag for the usage in the
-*automodule* and *autoclass* directive. See also the :ref:`examples` section
-for their usage.
-
+-------------------------------
 
 .. event:: autodocsumm-grouper (app, what, name, obj, section, parent)
 

--- a/docs/conf_settings.rst
+++ b/docs/conf_settings.rst
@@ -25,9 +25,9 @@ via
 
     autodoc_default_options = {'autosummary': True}
 
-See also the :ref:`examples` section it's usage.
+See also the usage in the :ref:`examples` section.
 
-The other additional flags let you control what should be in the autosummary
+The other additional flags lets you control what should be in the autosummary
 table: these are
 
 - ``autosummary-private-members``

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -90,3 +90,27 @@ your *conf.py*. Then you get
 
 .. autodata:: no_data_demo.d
     :noindex:
+
+.. _summary-table-example:
+
+Generating a summary table without the full documentation
+---------------------------------------------------------
+Using one of the ``autosummary-...`` options (e.g. ``autosummary-members``,
+see :ref:`autodoc-flags`) let's you create a summary table that points to the
+documentation in another point of the documentation. You should, however make
+sure to add the ``noindex`` flag and to add a ``no-members`` flag. For our
+:mod:`autodocsumm` module this for example then looks like::
+
+    .. automodule:: autodocsumm
+        :noindex:
+        :no-members:
+        :autosummary:
+        :autosummary-members:
+
+which gives us
+
+.. automodule:: autodocsumm
+    :noindex:
+    :no-members:
+    :autosummary:
+    :autosummary-members:

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -47,7 +47,7 @@ to the :event:`autodocsumm-grouper` event. For example, if you include::
 in your *conf.py*, you get :ref:`this <demo_grouper>`.
 
 Note that you can also include the *autosummary* flag in the
-:confval:`autodoc_default_flags` configuration value
+:confval:`autodoc_default_options` configuration value
 
 
 Including the ``__call__`` method

--- a/tests/sphinx_supp/conf.py
+++ b/tests/sphinx_supp/conf.py
@@ -1,12 +1,20 @@
 # -*- coding: utf-8 -*-
 import sys
+import sphinx
 sys.path.insert(0, '.')
 
 master_doc = 'index'
 
 extensions = ['autodocsumm']
 
-autodoc_default_flags = ['show_inheritance', 'autosummary', 'members']
+if tuple(map(int, sphinx.__version__.split('.')[:2])) < (2, 1):
+    autodoc_default_flags = ['show_inheritance', 'autosummary', 'members']
+else:
+    autodoc_default_options = {
+        'show_inheritance': True,
+        'autosummary': True,
+        'members': True
+        }
 
 not_document_data = [
     'dummy.large_data', 'dummy.TestClass.small_data',

--- a/tests/sphinx_supp/index.rst
+++ b/tests/sphinx_supp/index.rst
@@ -4,6 +4,8 @@ Example documentation
 .. toctree::
 
     test_module
+    test_module_summary_only
     test_class
+    test_class_summary_only
     test_inherited
     test_module_title

--- a/tests/sphinx_supp/test_class_summary_only.rst
+++ b/tests/sphinx_supp/test_class_summary_only.rst
@@ -1,0 +1,6 @@
+Dummy Class Doc with summary only
+=================================
+
+.. autoclass:: dummy.TestClass
+	:no-members:
+	:autosummary-members:

--- a/tests/sphinx_supp/test_module_summary_only.rst
+++ b/tests/sphinx_supp/test_module_summary_only.rst
@@ -1,0 +1,6 @@
+Docs of dummy test module with summary only
+===========================================
+
+.. automodule:: dummy
+	:no-members:
+	:autosummary-members:

--- a/tests/test_autodocsumm.py
+++ b/tests/test_autodocsumm.py
@@ -52,6 +52,20 @@ class TestAutosummaryDocumenter(unittest.TestCase):
 
     @with_app(buildername='html', srcdir=sphinx_supp,
               copy_srcdir_to_tmpdir=True)
+    def test_module_summary_only(self, app, status, warning):
+        app.build()
+        html = get_html(app, 'test_module_summary_only.html')
+        self.assertIn('<span class="pre">TestClass</span>', html)
+        self.assertIn('<span class="pre">test_func</span>', html)
+
+        # test whether the data is shown correctly
+        self.assertIn('<span class="pre">large_data</span>', html)
+        self.assertIn('<span class="pre">small_data</span>', html)
+
+        self.assertNotIn('<dt id="dummy.Class_CallTest">', html)
+
+    @with_app(buildername='html', srcdir=sphinx_supp,
+              copy_srcdir_to_tmpdir=True)
     def test_module_with_title(self, app, status, warning):
         app.build()
         html = get_html(app, 'test_module_title.html')
@@ -113,6 +127,26 @@ class TestAutosummaryDocumenter(unittest.TestCase):
         self.assertTrue(in_between(
             html, '<span class="pre">InnerClass</span>', 'Classes',
             'DummySection'))
+
+    @with_app(buildername='html', srcdir=sphinx_supp,
+              copy_srcdir_to_tmpdir=True)
+    def test_class_summary_only(self, app, status, warning):
+        app.build()
+        html = get_html(app, '/test_class_summary_only.html')
+
+        self.assertIn('<span class="pre">instance_attribute</span>', html)
+
+        self.assertIn('<span class="pre">test_method</span>', html)
+        self.assertIn('<span class="pre">test_attr</span>', html)
+
+        # test whether the right objects are included
+        self.assertIn('<span class="pre">class_caller</span>', html)
+
+        # test whether the data is shown correctly
+        self.assertIn('<span class="pre">large_data</span>', html)
+        self.assertIn('<span class="pre">small_data</span>', html)
+
+        self.assertNotIn('<dt id="dummy.TestClass.small_data">', html)
 
     @with_app(buildername='html', srcdir=sphinx_supp,
               copy_srcdir_to_tmpdir=True)


### PR DESCRIPTION
This PR adds the autosummary-members, autosummary-undoc-members, etc. options to create the summary tables without the need of the real documentation (see feature request at https://github.com/Chilipp/autodocsumm/issues/15)

Closes https://github.com/Chilipp/autodocsumm/issues/15

@maeddlae: Would you take a look at it? The idea is to have additional options that only affect the summary tables.

```
.. autoclass:: module.Class
    :autosummary:
    :autosummary-members:
    :no-members:
```

should do exactly what you want. It also works with all other options listed in the `autodocsumm.member_options attribute` (see https://github.com/Chilipp/autodocsumm/blob/12139d6fa335c85bf5f4cc63e87fc6a8c8ce4163/autodocsumm/__init__.py#L63-L68)