### PR TITLE
Allow disabling nesting of autosummary tables 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
   - SPHINX_VERSION=1.8.*
   - SPHINX_VERSION=2.0.*
   - SPHINX_VERSION=2.1.*
+  - SPHINX_VERSION=2.2.*
   - SPHINX_VERSION=""
 matrix:
   exclude:
@@ -23,6 +24,8 @@ matrix:
       env: SPHINX_VERSION=2.0.*
     - python: "2.7"
       env: SPHINX_VERSION=2.1.*
+    - python: "2.7"
+      env: SPHINX_VERSION=2.2.*
     - python: "3.7"
       env: SPHINX_VERSION=1.3.*
     - python: "3.7"

--- a/autodocsumm/__init__.py
+++ b/autodocsumm/__init__.py
@@ -787,12 +787,12 @@ def setup(app):
                 CallableAttributeDocumenter, NoDataDataDocumenter,
                 NoDataAttributeDocumenter]:
         if not issubclass(registry.get(cls.objtype), cls):
-            try:
-                # we use add_documenter because this does not add a new
-                # directive
-                app.add_documenter(cls)
-            except AttributeError:
+            if sphinx_version >= [2, 2]:
+                app.add_autodocumenter(cls, override=True)
+            elif sphinx_version >= [0, 6]:
                 app.add_autodocumenter(cls)
+            else:
+                app.add_documenter(cls)
 
     # directives
     if sphinx_version >= [1, 8]:

--- a/docs/conf_settings.rst
+++ b/docs/conf_settings.rst
@@ -38,10 +38,15 @@ table: these are
 - ``autosummary-imported-members``
 - ``autosummary-ignore-module-all``
 - ``autosummary-members``
+- ``autosummary-no-nesting``
 
 They are essentially the same as the options for :mod:`~sphinx.ext.autodoc`
 (i.e. ``private-members`` or ``members``), but they only affect the
 autosummary table (see the example in :ref:`summary-table-example`).
+
+The new additional flag ``autosummary-no-nesting`` only generates
+autosummary tables for a module, but not for members within. See
+:ref:`no-nesting-example`.
 
 
 .. _confvals:

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -124,16 +124,17 @@ Using the ``autosummary-no-nesting`` option, you can generate the autosummary
 table for a module without generating autosummary tables for members within
 that module. This is useful when you only want to use the autosummary table as
 a table of contents for a given page. For the :doc:`demo module <demo_module>`,
- here's an example:
+here's an example::
 
     .. automodule:: dummy
         :autosummary:
+        :members:
         :autosummary-no-nesting:
 
 which gives us
 
 .. automodule:: dummy
     :noindex:
+    :members:
     :autosummary:
     :autosummary-no-nesting:
-

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -114,3 +114,26 @@ which gives us
     :no-members:
     :autosummary:
     :autosummary-members:
+
+.. _no-nesting-example:
+
+Generating a summary table for the module without nesting
+---------------------------------------------------------
+
+Using the ``autosummary-no-nesting`` option, you can generate the autosummary
+table for a module without generating autosummary tables for members within
+that module. This is useful when you only want to use the autosummary table as
+a table of contents for a given page. For the :doc:`demo module <demo_module>`,
+ here's an example:
+
+    .. automodule:: dummy
+        :autosummary:
+        :autosummary-no-nesting:
+
+which gives us
+
+.. automodule:: dummy
+    :noindex:
+    :autosummary:
+    :autosummary-no-nesting:
+

--- a/tests/sphinx_supp/index.rst
+++ b/tests/sphinx_supp/index.rst
@@ -9,3 +9,4 @@ Example documentation
     test_class_summary_only
     test_inherited
     test_module_title
+    test_module_no_nesting

--- a/tests/sphinx_supp/test_module_no_nesting.rst
+++ b/tests/sphinx_supp/test_module_no_nesting.rst
@@ -1,5 +1,5 @@
-Docs of dummy test module
-=========================
+Docs of dummy test module without nesting
+=========================================
 
 .. automodule:: dummy
    :autosummary-no-nesting:

--- a/tests/sphinx_supp/test_module_no_nesting.rst
+++ b/tests/sphinx_supp/test_module_no_nesting.rst
@@ -1,0 +1,5 @@
+Docs of dummy test module
+=========================
+
+.. automodule:: dummy
+   :autosummary-no-nesting:

--- a/tests/test_autodocsumm.py
+++ b/tests/test_autodocsumm.py
@@ -52,6 +52,26 @@ class TestAutosummaryDocumenter(unittest.TestCase):
 
     @with_app(buildername='html', srcdir=sphinx_supp,
               copy_srcdir_to_tmpdir=True)
+    def test_module_no_nesting(self, app, status, warning):
+        app.build()
+        html = get_html(app, 'test_module_no_nesting.html')
+
+        self.assertIn('<span class="pre">TestClass</span>', html)
+        self.assertIn('<span class="pre">test_func</span>', html)
+
+        # test whether the data is shown correctly
+        self.assertIn('<span class="pre">large_data</span>', html)
+        self.assertIn('<span class="pre">small_data</span>', html)
+
+        # test that elements of TestClass are not autosummarized, since nesting is disabled.
+        self.assertNotIn('<span class="pre">test_method</span>', html)
+        self.assertNotIn('<span class="pre">test_attr</span>', html)
+
+        # test the members are still displayed
+        self.assertIn('<dt id="dummy.Class_CallTest">', html)
+
+    @with_app(buildername='html', srcdir=sphinx_supp,
+              copy_srcdir_to_tmpdir=True)
     def test_module_summary_only(self, app, status, warning):
         app.build()
         html = get_html(app, 'test_module_summary_only.html')


### PR DESCRIPTION
I've opened a draft PR for allowing disabling of nesting of autosummary tables. The use case is described in #19 

Closes #19, #13 

Once we finalize on the solution, I can add the necessary tests.