### PR TITLE
Default falsy 'get_doc' result to the empty-list

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.5, 3.6, 3.7, 3.8]
-        sphinx-version: ["", "3.2.*",  "3.1.*", "3.0.*", "2.4.*", "2.3.*", "2.2.*"]
+        sphinx-version: ["", "3.5.*", "3.4.*", "3.2.*",  "3.1.*", "3.0.*", "2.4.*", "2.3.*", "2.2.*"]
 
     steps:
     - uses: actions/checkout@v2

--- a/autodocsumm/__init__.py
+++ b/autodocsumm/__init__.py
@@ -303,7 +303,7 @@ class AutoSummModuleDocumenter(ModuleDocumenter, AutosummaryDocumenter):
 
         self.add_autosummary()
 
-        if self.options.autosummary_no_nesting:
+        if self.options.get("autosummary-no-nesting"):
             self.options["no-autosummary"] = "True"
 
 

--- a/autodocsumm/__init__.py
+++ b/autodocsumm/__init__.py
@@ -20,7 +20,7 @@ from sphinx.util.docutils import SphinxDirective
 
 from sphinx.ext.autodoc import (
     ClassDocumenter, ModuleDocumenter, ALL, PycodeError,
-    ModuleAnalyzer, bool_option, AttributeDocumenter, DataDocumenter, Options,
+    ModuleAnalyzer, AttributeDocumenter, DataDocumenter, Options,
     prepare_docstring)
 import sphinx.ext.autodoc as ad
 
@@ -83,6 +83,10 @@ elif Signature is not None:  # sphinx >= 1.7
 def list_option(option):
     """Transform a string to a list by splitting at ;;."""
     return [s.strip() for s in option.split(";;")]
+
+
+def bool_option(*args):
+    return "True"
 
 
 class AutosummaryDocumenter(object):
@@ -230,7 +234,10 @@ class AutosummaryDocumenter(object):
 
     def add_autosummary(self):
         """Add the autosammary table of this documenter."""
-        if self.options.autosummary:
+        if (
+            self.options.get("autosummary")
+            and not self.options.get("no-autosummary")
+        ):
 
             grouped_documenters = self.get_grouped_documenters()
 
@@ -297,7 +304,7 @@ class AutoSummModuleDocumenter(ModuleDocumenter, AutosummaryDocumenter):
         self.add_autosummary()
 
         if self.options.autosummary_no_nesting:
-            self.options.autosummary = False
+            self.options["no-autosummary"] = "True"
 
 
 class AutoSummClassDocumenter(ClassDocumenter, AutosummaryDocumenter):
@@ -524,10 +531,10 @@ class AutoDocSummDirective(SphinxDirective):
         objtype = self.name[4:-4]  # strip prefix (auto-) and suffix (-summ).
         doccls = self.env.app.registry.documenters[objtype]
 
-        self.options['autosummary-force-inline'] = True
-        self.options['autosummary'] = True
+        self.options['autosummary-force-inline'] = "True"
+        self.options['autosummary'] = "True"
         if 'no-members' not in self.options:
-            self.options['members'] = True
+            self.options['members'] = ""
 
         # process the options with the selected documenter's option_spec
         try:

--- a/autodocsumm/__init__.py
+++ b/autodocsumm/__init__.py
@@ -155,7 +155,7 @@ class AutosummaryDocumenter(object):
             self.env.temp_data['autodoc:class'] = self.objpath[0]
 
         if not self.options.autosummary_force_inline:
-            docstring = self.get_doc()
+            docstring = self.get_doc() or []
             autodocsumm_directive = '.. auto%ssumm::' % self.objtype
             for s in chain.from_iterable(docstring):
                 if autodocsumm_directive in s:

--- a/tests/sphinx_supp/conf.py
+++ b/tests/sphinx_supp/conf.py
@@ -20,6 +20,8 @@ not_document_data = [
     'dummy.large_data', 'dummy.TestClass.small_data',
     'dummy_title.large_data', 'dummy_title.TestClass.small_data']
 
+autodoc_typehints = "description"
+
 autodata_content = 'both'
 
 

--- a/tests/test_autodocsumm.py
+++ b/tests/test_autodocsumm.py
@@ -49,7 +49,6 @@ class TestAutosummaryDocumenter(unittest.TestCase):
         self.assertIn('<span class="pre">large_data</span>', html)
         self.assertIn('<span class="pre">small_data</span>', html)
 
-        self.assertNotIn('Should be skipped', html)
         try:
             self.assertIn('Should be included', html)
         except AssertionError: # sphinx>=3.5
@@ -59,8 +58,15 @@ class TestAutosummaryDocumenter(unittest.TestCase):
                 '<span class="pre">included\'</span>',
                 html
             )
+            self.assertNotIn(
+                '<span class="pre">\'Should</span> '
+                '<span class="pre">be</span> '
+                '<span class="pre">skipped\'</span>',
+                html
+            )
+        else:
+            self.assertNotIn('Should be skipped', html)
 
-        self.assertNotIn('Should also be skipped', html)
         try:
             self.assertIn('Should also be included', html)
         except AssertionError: # sphinx>=3.5
@@ -71,6 +77,15 @@ class TestAutosummaryDocumenter(unittest.TestCase):
                 '<span class="pre">included\'</span>',
                 html
             )
+            self.assertNotIn(
+                '<span class="pre">\'Should</span> '
+                '<span class="pre">also</span> '
+                '<span class="pre">be</span> '
+                '<span class="pre">skipped\'</span>',
+                html
+            )
+        else:
+            self.assertNotIn('Should also be skipped', html)
 
     @with_app(buildername='html', srcdir=sphinx_supp,
               copy_srcdir_to_tmpdir=True)
@@ -86,8 +101,18 @@ class TestAutosummaryDocumenter(unittest.TestCase):
         self.assertIn('<span class="pre">small_data</span>', html)
 
         # test that elements of TestClass are not autosummarized, since nesting is disabled.
-        self.assertNotIn('<span class="pre">test_method</span>', html)
-        self.assertNotIn('<span class="pre">test_attr</span>', html)
+        try:
+            self.assertNotIn('<span class="pre">test_method</span>', html)
+            self.assertNotIn('<span class="pre">test_attr</span>', html)
+        except AssertionError:  # sphinx>=3.5
+            self.assertEqual(
+                len(re.findall('<span class="pre">test_method</span>', html)),
+                1,
+            )
+            self.assertEqual(
+                len(re.findall('<span class="pre">test_attr</span>', html)),
+                1,
+            )
 
         # test the members are still displayed
         self.assertIn('<dt id="dummy.Class_CallTest">', html)
@@ -123,12 +148,42 @@ class TestAutosummaryDocumenter(unittest.TestCase):
         # test whether the data is shown correctly
         self.assertIn('<span class="pre">large_data</span>', html)
         self.assertIn('<span class="pre">small_data</span>', html)
-
-        self.assertNotIn('Should be skipped', html)
-        self.assertIn('Should be included', html)
-
-        self.assertNotIn('Should also be skipped', html)
-        self.assertIn('Should also be included', html)
+        try:
+            self.assertIn('Should be included', html)
+        except AssertionError: # sphinx>=3.5
+            self.assertIn(
+                '<span class="pre">\'Should</span> '
+                '<span class="pre">be</span> '
+                '<span class="pre">included\'</span>',
+                html
+            )
+            self.assertNotIn(
+                '<span class="pre">\'Should</span> '
+                '<span class="pre">be</span> '
+                '<span class="pre">skipped\'</span>',
+                html
+            )
+        else:
+            self.assertNotIn('Should be skipped', html)
+        try:
+            self.assertIn('Should also be included', html)
+        except AssertionError: # sphinx>=3.5
+            self.assertIn(
+                '<span class="pre">\'Should</span> '
+                '<span class="pre">also</span> '
+                '<span class="pre">be</span> '
+                '<span class="pre">included\'</span>',
+                html
+            )
+            self.assertNotIn(
+                '<span class="pre">\'Should</span> '
+                '<span class="pre">also</span> '
+                '<span class="pre">be</span> '
+                '<span class="pre">skipped\'</span>',
+                html
+            )
+        else:
+            self.assertNotIn('Should also be skipped', html)
 
     @with_app(buildername='html', srcdir=sphinx_supp,
               copy_srcdir_to_tmpdir=True)

--- a/tests/test_autodocsumm.py
+++ b/tests/test_autodocsumm.py
@@ -50,10 +50,27 @@ class TestAutosummaryDocumenter(unittest.TestCase):
         self.assertIn('<span class="pre">small_data</span>', html)
 
         self.assertNotIn('Should be skipped', html)
-        self.assertIn('Should be included', html)
+        try:
+            self.assertIn('Should be included', html)
+        except AssertionError: # sphinx>=3.5
+            self.assertIn(
+                '<span class="pre">\'Should</span> '
+                '<span class="pre">be</span> '
+                '<span class="pre">included\'</span>',
+                html
+            )
 
         self.assertNotIn('Should also be skipped', html)
-        self.assertIn('Should also be included', html)
+        try:
+            self.assertIn('Should also be included', html)
+        except AssertionError: # sphinx>=3.5
+            self.assertIn(
+                '<span class="pre">\'Should</span> '
+                '<span class="pre">also</span> '
+                '<span class="pre">be</span> '
+                '<span class="pre">included\'</span>',
+                html
+            )
 
     @with_app(buildername='html', srcdir=sphinx_supp,
               copy_srcdir_to_tmpdir=True)
@@ -146,7 +163,15 @@ class TestAutosummaryDocumenter(unittest.TestCase):
         self.assertIn('<span class="pre">small_data</span>', html)
 
         self.assertNotIn('Should be skipped', html)
-        self.assertIn('Should be included', html)
+        try:
+            self.assertIn('Should be included', html)
+        except AssertionError: # sphinx>=3.5
+            self.assertIn(
+                '<span class="pre">\'Should</span> '
+                '<span class="pre">be</span> '
+                '<span class="pre">included\'</span>',
+                html
+            )
 
         self.assertIn('DummySection', html)
         self.assertTrue(in_between(


### PR DESCRIPTION
Fixes `TypeError: 'NoneType' object is not iterable` when using Sphinx v3.4 or later. Sphinx v3.4 (specifically sphinx-doc/sphinx@6c645e4) made `Documenter.get_doc` for variables which were aliases of classes return `None`