### PR TITLE
Fix: no links generated in summary table

### DIFF
--- a/autodocsumm/__init__.py
+++ b/autodocsumm/__init__.py
@@ -279,8 +279,15 @@ class AutosummaryDocumenter(object):
         self.options.update(options_save)
         return documenters
 
-    def add_autosummary(self):
-        """Add the autosammary table of this documenter."""
+    def add_autosummary(self, relative_ref_paths=False):
+        """Add the autosammary table of this documenter.
+
+        Parameters
+        ==========
+        relative_ref_paths: bool
+            Use paths relative to the current module instead of
+            absolute import paths for each object
+        """
         if (
             self.options.get("autosummary")
             and not self.options.get("no-autosummary")
@@ -303,8 +310,14 @@ class AutosummaryDocumenter(object):
                 indent = '    '
 
                 for (documenter, _) in documenters:
-                    self.add_line(
-                        indent + '~' + documenter.fullname, sourcename)
+                    if relative_ref_paths:
+                        obj_ref_path = documenter.fullname.lstrip(
+                            self.modname + '.')
+                    else:
+                        obj_ref_path = documenter.fullname
+
+                    self.add_line(indent + '~' + obj_ref_path, sourcename)
+
                 self.add_line('', sourcename)
 
 
@@ -351,7 +364,7 @@ class AutoSummModuleDocumenter(ModuleDocumenter, AutosummaryDocumenter):
     def add_content(self, *args, **kwargs):
         super().add_content(*args, **kwargs)
 
-        self.add_autosummary()
+        self.add_autosummary(relative_ref_paths=True)
 
         if self.options.get("autosummary-no-nesting"):
             self.options["no-autosummary"] = "True"
@@ -400,7 +413,7 @@ class AutoSummClassDocumenter(ClassDocumenter, AutosummaryDocumenter):
     def add_content(self, *args, **kwargs):
         super().add_content(*args, **kwargs)
 
-        self.add_autosummary()
+        self.add_autosummary(relative_ref_paths=True)
 
 
 class CallableDataDocumenter(DataDocumenter):

--- a/autodocsumm/__init__.py
+++ b/autodocsumm/__init__.py
@@ -310,11 +310,11 @@ class AutosummaryDocumenter(object):
                 indent = '    '
 
                 for (documenter, _) in documenters:
+                    obj_ref_path = documenter.fullname
                     if relative_ref_paths:
-                        obj_ref_path = documenter.fullname.lstrip(
-                            self.modname + '.')
-                    else:
-                        obj_ref_path = documenter.fullname
+                        modname = self.modname + "."
+                        if documenter.fullname.startswith(modname):
+                            obj_ref_path = documenter.fullname[len(modname):]
 
                     self.add_line(indent + '~' + obj_ref_path, sourcename)
 

--- a/tests/test-root/dummy_submodule/submodule1.py
+++ b/tests/test-root/dummy_submodule/submodule1.py
@@ -1,0 +1,9 @@
+import dummy_submodule.submodule2
+
+
+class SubmoduleClass1:
+    """Docu for myclass 1"""
+
+    def func1(self):
+        """Docu for func 1"""
+        pass

--- a/tests/test-root/dummy_submodule/submodule2.py
+++ b/tests/test-root/dummy_submodule/submodule2.py
@@ -1,0 +1,9 @@
+import dummy_submodule.submodule1
+
+
+class SubmoduleClass2:
+    """Docu for myclass 1"""
+
+    def func2(self):
+        """Docu for func 1"""
+        pass

--- a/tests/test-root/index.rst
+++ b/tests/test-root/index.rst
@@ -17,3 +17,5 @@ Example documentation
     test_automodulesumm
     test_automodulesumm_some_sections
     test_empty
+    test_class_submodule
+    test_module_submodule

--- a/tests/test-root/test_class_submodule.rst
+++ b/tests/test-root/test_class_submodule.rst
@@ -1,0 +1,4 @@
+Test if links in summary are correctly generated
+================================================
+
+.. autoclass:: dummy_submodule.submodule1.SubmoduleClass1

--- a/tests/test-root/test_module_submodule.rst
+++ b/tests/test-root/test_module_submodule.rst
@@ -1,0 +1,4 @@
+Test if links in summary are correctly generated
+================================================
+
+.. automodule:: dummy_submodule.submodule2

--- a/tests/test_autodocsumm.py
+++ b/tests/test_autodocsumm.py
@@ -366,6 +366,28 @@ class TestAutosummaryDocumenter:
 
         assert docstring_end > methods_start
 
+    def test_class_submodule(self, app):
+        app.build()
+
+        html = get_html(app, '/test_class_submodule.html')
+
+        # check that hyperlink for instance method exists in summary table
+        assert re.findall(r'<td>.*href="#dummy_submodule\.submodule1'
+                          r'\.SubmoduleClass1\.func1".*</td>', html)
+
+    def test_module_submodule(self, app):
+        app.build()
+
+        html = get_html(app, '/test_module_submodule.html')
+
+        # check that hyperlink for class exists in summary table
+        assert re.findall(r'<td>.*href="#dummy_submodule\.submodule2'
+                          r'\.SubmoduleClass2".*</td>', html)
+
+        # check that hyperlink for instance method exists in summary table
+        assert re.findall(r'<td>.*href="#dummy_submodule\.submodule2'
+                          r'\.SubmoduleClass2\.func2".*</td>', html)
+
 
 class TestAutoDocSummDirective:
     """Test case for the :class:`autodocsumm.AutoDocSummDirective`."""

--- a/tests/test_autodocsumm.py
+++ b/tests/test_autodocsumm.py
@@ -212,10 +212,7 @@ class TestAutosummaryDocumenter:
         if sphinx_version[:2] > [3, 1]:
             assert in_autosummary("instance_attribute", html)
         elif sphinx_version[:2] < [3, 1]:
-            assert (
-                '<span class="pre">dummy.TestClass.instance_attribute</span>'
-                in html
-            )
+            assert in_autosummary("TestClass.instance_attribute", html)
 
         assert in_autosummary("test_method", html)
         assert in_autosummary("test_attr", html)
@@ -267,10 +264,7 @@ class TestAutosummaryDocumenter:
         if sphinx_version[:2] > [3, 1]:
             assert in_autosummary("instance_attribute", html)
         elif sphinx_version[:2] < [3, 1]:
-            assert (
-                '<span class="pre">dummy.TestClass.instance_attribute</span>'
-                in html
-            )
+            assert in_autosummary("TestClass.instance_attribute", html)
 
         assert in_autosummary("test_attr", html)
         assert in_autosummary("large_data", html)
@@ -287,10 +281,7 @@ class TestAutosummaryDocumenter:
         if sphinx_version[:2] > [3, 1]:
             assert in_autosummary("instance_attribute", html)
         elif sphinx_version[:2] < [3, 1]:
-            assert (
-                '<span class="pre">dummy.TestClass.instance_attribute</span>'
-                in html
-            )
+            assert in_autosummary("TestClass.instance_attribute", html)
 
         assert in_autosummary("test_method", html)
         assert in_autosummary("test_attr", html)
@@ -314,10 +305,7 @@ class TestAutosummaryDocumenter:
         if sphinx_version[:2] > [3, 1]:
             assert in_autosummary("instance_attribute", html)
         elif sphinx_version[:2] < [3, 1]:
-            assert (
-                '<span class="pre">dummy.TestClass.instance_attribute</span>'
-                in html
-            )
+            assert in_autosummary("TestClass.instance_attribute", html)
 
         assert in_autosummary("test_method", html)
         assert in_autosummary("test_attr", html)


### PR DESCRIPTION
This pull request fixes #65 and #67.

Description
-----------

In some specific cases, dependent on the import structure of a project, summary tables generated by autodocsumm do not contain hyperlinks to the referenced objects. This only happens if imports of top level modules allow a "circular" reference to an object or module (such a reference is not necessarily a valid import path).  Assuming the following project structure

```
my_module
├─ submodule1
├─ submodule2
```

the problem occurs if `submodule1.py` contains an import that exposes the namespace of `my_module`. For example `import my_module`, `import my_module.submodule2` and variations thereof. This theoretically allows to reference `my_module.submodule1` as `my_module.submodule1.my_module.submodule1`.

Furthermore, the problem only occurs, when the `:autosummary:` option is used within a `.. automodule::` or `.. autoclass::` directive. 

The problem does not occur when using `.. autoclasssumm`, `.. automodulesumm`.

#67 provides a minimal example to reproduce the problem.


Solution
--------

The reason for this problem is given in https://github.com/sphinx-doc/sphinx/pull/6792#issuecomment-549833172

The `.. automodule::` and `.. autoclass::` directives use the `:module:` option to modify the current module. Any `.. autosummary::` directive added inside one of these directives should therefore reference objects relative to the 'current module'.

At the moment, the `:autosummary:` option generates the following intermediary output:

```
.. py:class:: MyClass()
   :module: dummy.submodule1
   Docu for my class

   **Methods:**

   .. autosummary::
       ~dummy.submodule1.MyClass.func1
```

This pull requests changes the behaviour, so that the output uses relative references:

```
.. py:class:: MyClass()
   :module: dummy.submodule1
   Docu for my class

   **Methods:**

   .. autosummary::
       ~MyClass.func1
```


Note
-----

It is actually not the case, that the output generated by autodocsumm stops working in case of a specific import structure. The objects should always be referenced relative to the current module. Therefore, it is the case that the output sometimes works, despite being incorrect.

Implementation
----------------

Sphinx' autodoc sets `:module:` to `self.modname`. See: 

https://github.com/sphinx-doc/sphinx/blob/40a8f2b54a04872fea24d316baf0c39066897c2d/sphinx/ext/autodoc/__init__.py#L546-L548

To correct for this, the fix in this PR strips `self.modname` from the beginning of the reference. No check is done to ensure that the result is a valid reference path. Tests have shown that this is sufficient. Verifying the resulting import path will certainly be slower, but could be done if necessary.

The change is implemented so that `.add_autosummary` defaults to the old behaviour of using absolute references. This is required for other directives.

Tests
-----

Test have been added. I'm not familiar with the sphinx testing framework used here, therefore, some changes might be necessary.

I have also built the documentation of two larger projects of mine with this change. All missing links in summary tables were added correctly, and I could not spot any other problems.