### PR TITLE
Fix ci test failures 

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -31,10 +31,12 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         SPHINX=Sphinx
+        JINJA2=jinja2
         if [[ $SPHINX_VERSION != "" ]]; then
           SPHINX="${SPHINX}==${SPHINX_VERSION}";
+          JINJA2="${JINJA2}<3.1";
         fi
-        pip install pytest pytest-cov codecov "${SPHINX}" -e .
+        pip install pytest pytest-cov codecov "${SPHINX}" "${JINJA2}" -e .
     - name: Test with pytest
       run: |
         pytest --cov=autodocsumm --cov-report=xml tests


### PR DESCRIPTION
Reason for the ci failures: Sphinx <= 4.0.1 is incompatible with jinja2 >= 3.1

I pinned the jinja2 dependency in all relevant ci runs. This means, only the CI run with no additional version requirement for sphinx runs with jinja2 not pinned.

See https://github.com/sphinx-doc/sphinx/issues/10291 for reference