### PR TITLE
Use bs4 for tests

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -36,7 +36,7 @@ jobs:
           SPHINX="${SPHINX}==${SPHINX_VERSION}";
           JINJA2="${JINJA2}<3.1";
         fi
-        pip install pytest pytest-cov codecov "${SPHINX}" "${JINJA2}" -e .
+        pip install pytest pytest-cov codecov "${SPHINX}" "${JINJA2}" beautifulsoup4 -e .
     - name: Test with pytest
       run: |
         pytest --cov=autodocsumm --cov-report=xml tests


### PR DESCRIPTION
as realized in https://github.com/Chilipp/autodocsumm/pull/70#issuecomment-1102287393, the current test methods to not work anymore with `sphinx>4.0`. This PR is fixing this issue and implements a new test method based on beautifulsoup4