### PR TITLE
fix build with Sphinx 7.2

### DIFF
--- a/tests/test_autodocsumm.py
+++ b/tests/test_autodocsumm.py
@@ -36,7 +36,7 @@ def in_between(full, sub, s0, *others):
 
 
 def get_html(app, fname):
-    with open(app.outdir + '/' + fname) as f:
+    with open(str(app.outdir) + '/' + fname) as f:
         return f.read()
 
 

--- a/tests/test_autodocsumm.py
+++ b/tests/test_autodocsumm.py
@@ -36,8 +36,7 @@ def in_between(full, sub, s0, *others):
 
 
 def get_html(app, fname):
-    with open(str(app.outdir) + '/' + fname) as f:
-        return f.read()
+    return (app.outdir / fname).read_text()
 
 
 def in_autosummary(what, html) -> bool:


### PR DESCRIPTION
The new version of Sphinx changed some output types, this tiny change was enough to run the tests with Sphinx 7.2.2.

I didn't build the docs, so I left the pin in `docs/requirements.txt` as it is.