### PR TITLE
Allow Sphinx >=8.0 and fix deprecations; allow Python 3.12; rework test workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,40 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Tests
+
+on:
+  workflow_call:
+    inputs:
+      python-version:
+        required: true
+        type: string
+      extra-requirements:
+        required: false
+        type: string
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ inputs.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ inputs.python-version }}
+    - name: Display Python version
+      run: python -c "import sys; print(sys.version)"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pytest pytest-cov codecov beautifulsoup4 ${{ inputs.extra-requirements }} -e .
+    - name: Test with pytest
+      run: |
+        pytest --cov=autodocsumm --cov-report=xml tests
+    - name: Upload codecov
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      run: |
+        codecov

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -33,14 +33,14 @@ jobs:
       matrix:
         python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
         sphinx-version: [
-          "7.0.*", "7.1.*", "7.2.*",
-          "6.0.*",
-          "5.0.*",
-          "4.5.*"
+          "7.0.*",  # possible range: 7.0.0 - 7.4.7
+          "6.0.*",  # possible range: 6.0.0 - 6.2.1
+          "5.0.*",  # possible range: 5.0.0 - 5.3.0
+          "4.5.*"   # possible range: 4.5.0, also latest that supports py3.8
         ]
-        exclude:
-          - python-version: "3.8"
-            sphinx-version: "7.2.*"
+        include:
+          - python-version: "3.9"
+            sphinx-version: "7.2.*"  # latest version that supports py3.9
     uses: ./.github/workflows/build.yml
     with:
       python-version: ${{ matrix.python-version }}
@@ -62,7 +62,7 @@ jobs:
       matrix:
         python-version: [ "3.8", "3.9" ]
         sphinx-version: [
-          "4.4.*", "4.3.*", "4.2.*", "4.1.*", "4.0.*"
+          "4.0.*"  # possible range: 4.0.0 - 4.4.0
         ]
     uses: ./.github/workflows/build.yml
     with:
@@ -85,8 +85,11 @@ jobs:
       matrix:
         python-version: [ "3.7", "3.8", "3.9" ]
         sphinx-version: [
-          "3.5.*", "3.4.*", "3.2.*",  "3.1.*", "3.0.*",
+          "3.0.*",  # possible range: 3.0.0 - 3.5.4
         ]
+        include:
+          - python-version: "3.7"
+            sphinx-version: "3.5.*"  # latest version that supports py3.7
     uses: ./.github/workflows/build.yml
     with:
       python-version: ${{ matrix.python-version }}

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -8,62 +8,95 @@ on:
   pull_request:
 
 jobs:
-  build:
 
-    runs-on: ubuntu-latest
+  build-sphinx-80plus:
+    name: Build
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [ "3.10", "3.11", "3.12" ]
+        sphinx-version: [
+          "8.0.*", "8.*"  # 8.0.x and latest
+        ]
+    uses: ./.github/workflows/build.yml
+    with:
+      python-version: ${{ matrix.python-version }}
+      extra-requirements: '\
+        "sphinx==${{ matrix.sphinx-version }}"'
+
+
+  build-legacy-sphinx-45plus:
+    name: Build
 
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9"]
+        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
         sphinx-version: [
-          "7.0.*", "7.1.*", "7.2.*", 
+          "7.0.*", "7.1.*", "7.2.*",
           "6.0.*",
           "5.0.*",
-          "4.5", "4.4", "4.3", "4.2", "4.1", "4.0.*",
-          "3.5.*", "3.4.*", "3.2.*",  "3.1.*", "3.0.*",
+          "4.5.*"
         ]
-        include:
-          - python-version: "3.7"
-            sphinx-version: ""
-          - python-version: "3.7"
-            sphinx-version: "3.5"
-          - python-version: "3.10"
-            sphinx-version: ""
-          - python-version: "3.10"
-            sphinx-version: "4.5"
-          - python-version: "3.11"
-            sphinx-version: ""
-          - python-version: "3.11"
-            sphinx-version: "4.5"
         exclude:
           - python-version: "3.8"
             sphinx-version: "7.2.*"
+    uses: ./.github/workflows/build.yml
+    with:
+      python-version: ${{ matrix.python-version }}
+      extra-requirements: '\
+        "sphinx==${{ matrix.sphinx-version }}"
+        "sphinxcontrib-applehelp<1.0.8"
+        "sphinxcontrib-devhelp<1.0.6"
+        "sphinxcontrib-htmlhelp<2.0.5"
+        "sphinxcontrib-jsmath<1.0.1"
+        "sphinxcontrib-qthelp<1.0.7"
+        "sphinxcontrib-serializinghtml<1.1.10"'
 
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Display Python version
-      run: python -c "import sys; print(sys.version)"
-    - name: Install dependencies
-      env:
-        SPHINX_VERSION: ${{ matrix.sphinx-version }}
-      run: |
-        python -m pip install --upgrade pip
-        SPHINX=Sphinx
-        JINJA2=jinja2
-        if [[ $SPHINX_VERSION != "" ]]; then
-          SPHINX="${SPHINX}==${SPHINX_VERSION}";
-          JINJA2="${JINJA2}<3.1";
-        fi
-        pip install pytest pytest-cov codecov "${SPHINX}" "${JINJA2}" beautifulsoup4 -e .
-    - name: Test with pytest
-      run: |
-        pytest --cov=autodocsumm --cov-report=xml tests
-    - name: Upload codecov
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      run: |
-        codecov
+
+  build-legacy-sphinx-40plus:
+    name: Build
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [ "3.8", "3.9" ]
+        sphinx-version: [
+          "4.4.*", "4.3.*", "4.2.*", "4.1.*", "4.0.*"
+        ]
+    uses: ./.github/workflows/build.yml
+    with:
+      python-version: ${{ matrix.python-version }}
+      extra-requirements: '\
+        "sphinx==${{ matrix.sphinx-version }}"
+        "sphinxcontrib-applehelp<1.0.8"
+        "sphinxcontrib-devhelp<1.0.6"
+        "sphinxcontrib-htmlhelp<2.0.5"
+        "sphinxcontrib-jsmath<1.0.1"
+        "sphinxcontrib-qthelp<1.0.7"
+        "sphinxcontrib-serializinghtml<1.1.10"'
+
+
+  build-legacy-sphinx-30plus:
+    name: Build
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [ "3.7", "3.8", "3.9" ]
+        sphinx-version: [
+          "3.5.*", "3.4.*", "3.2.*",  "3.1.*", "3.0.*",
+        ]
+    uses: ./.github/workflows/build.yml
+    with:
+      python-version: ${{ matrix.python-version }}
+      extra-requirements: '\
+        "sphinx==${{ matrix.sphinx-version }}"
+        "jinja2<3.1"
+        "alabaster<0.7.14"
+        "sphinxcontrib-applehelp<1.0.8"
+        "sphinxcontrib-devhelp<1.0.6"
+        "sphinxcontrib-htmlhelp<2.0.5"
+        "sphinxcontrib-jsmath<1.0.1"
+        "sphinxcontrib-qthelp<1.0.7"
+        "sphinxcontrib-serializinghtml<1.1.10"'

--- a/conftest.py
+++ b/conftest.py
@@ -1,11 +1,15 @@
 import os.path as osp
-import sys
 import pytest
+import sphinx
+import sys
+from packaging.version import Version
 
-from sphinx.testing.path import path
+if Version(sphinx.__version__) < Version("8.0.0"):
+    from sphinx.testing.path import path
+else:
+    from pathlib import Path as path
 
 pytest_plugins = 'sphinx.testing.fixtures'
-
 
 
 sphinx_supp = osp.abspath(osp.join(osp.dirname(__file__), "tests"))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
+    'Programming Language :: Python :: 3.12',
     'Operating System :: OS Independent',
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 
 requires-python = '>= 3.7'
 dependencies = [
-    'Sphinx >= 2.2, < 8.0',
+    'Sphinx >= 2.2, < 9.0',
 ]
 
 [project.urls]


### PR DESCRIPTION
This PR....

1. ... allows using autodocsumm with Sphinx >= 8.0 and adresses the (single) relevant deprecation. I have read through the Sphinx changelog and there is nothing that looks problematic that hasn't come up in the tests.

2. ... allows using autodocsumm with Python 3.12. There seems to be nothing preventing this. Tests are passing just fine.

3. ... reworks the test workflow (a lot). The ``sphinxcontrib-*`` packages as well as the ``alabaster`` package have had new releases in the last few months. The newer versions of these packages now require specific minimum versions of Sphinx (only) at runtime using ``app.require_sphinx()``. This means that pip is not able to resolve this (reverse) version constraint. Therefore, those packages need to be manually pinned to lower versions for older versions of Sphinx. As a result, the already complex version dependencies and pinning becomes even more convoluted. 
The new implementation is overall longer but much more explicit in defining the version combinations of Python, Sphinx and extra dependencies. Overall, this greatly improves the readability of what's going on here, in my opinion. I may have overdone it with the DRY principle by refactoring the actual test run steps into a separate workflow that is called from the various matrix combination steps. But I didn't just want to repeat those steps a bunch of times.
As a result of these changes, the tested combinations of Python and Sphinx are not exactly equivalent to before. I took the following approach for defining the new test matrices: 

    - test one release of each major Sphinx version at every supported Python version 
    - AND for each Python version, test the latest Sphinx release that supports it
    - AND test the very latest Sphinx 8.x release at every supported Python version

Feel free to disagree with me on the workflow changes. Maybe this is a personal preference thing as well. But I really didn't want to add any more includes and excludes as well as conditionals for dependency versions.

The commits are intentionally left as they are to maybe make my chain of thought more understandable.

Closes #97
