### PR TITLE
Fix ObjectMember related deprecation/removal

### DIFF
--- a/autodocsumm/__init__.py
+++ b/autodocsumm/__init__.py
@@ -220,8 +220,16 @@ class AutosummaryDocumenter(object):
 
         # remove members given by exclude-members
         if self.options.exclude_members:
-            members = [(membername, member) for (membername, member) in members
-                       if membername not in self.options.exclude_members]
+            try:
+                members = [
+                    member for member in members
+                    if member.__name__ not in self.options.exclude_members
+                ]
+            except AttributeError:  # Sphinx<3.4.0
+                members = [
+                    (membername, member) for (membername, member) in members
+                    if membername not in self.options.exclude_members
+                ]
 
         # document non-skipped members
         memberdocumenters = []

--- a/tests/test-root/index.rst
+++ b/tests/test-root/index.rst
@@ -5,6 +5,7 @@ Example documentation
 
     test_module
     test_module_summary_only
+    test_module_exclude_members
     test_class
     test_class_order
     test_class_summary_only

--- a/tests/test-root/test_module_exclude_members.rst
+++ b/tests/test-root/test_module_exclude_members.rst
@@ -1,0 +1,5 @@
+Docs of dummy test without some members
+=======================================
+
+.. automodule:: dummy
+    :autosummary-exclude-members: InheritedTestClass,

--- a/tests/test_autodocsumm.py
+++ b/tests/test_autodocsumm.py
@@ -484,6 +484,17 @@ class TestAutoDocSummDirective:
 
         assert '()' not in html
 
+    def test_automodulesumm_exclude_members(self, app):
+        """Test building the autosummary of a module with some members
+        excluded from the autosummary."""
+        app.build()
+
+        html = get_html(app, 'test_module_exclude_members.html')
+
+        assert in_autosummary("TestClass", html)
+        assert not in_autosummary("InheritedTestClass", html)
+
+
     def test_empty(self, app):
         app.build()
 


### PR DESCRIPTION
Closes #89

The relevant section of code was not covered by tests previously. Therefore, I've added a test that increases coverage to this part and generally verifies that ``:exclude-members:`` are handled correctly.

This issue only occurred when ``:exclude-members:`` was used which is why it did only come up in some projects.

To test against a real project, I've built the documentation for https://github.com/pyfar/pyfar (issue https://github.com/pyfar/pyfar/issues/661 linked in #89). As expected, the documentation build fails with Sphinx 8 and current autodocsumm and succeeds after this fix.