### PR TITLE
Don't document class attributes that are an alias to another object

### DIFF
--- a/autodocsumm/__init__.py
+++ b/autodocsumm/__init__.py
@@ -414,7 +414,11 @@ class AutoSummClassDocumenter(ClassDocumenter, AutosummaryDocumenter):
     def add_content(self, *args, **kwargs):
         super().add_content(*args, **kwargs)
 
-        self.add_autosummary(relative_ref_paths=True)
+        # If the class is already documented under another name, Sphinx
+        # documents it as data/attribute. In this case, we do not want to
+        # generate an autosummary of the class for the attribute (see #69).
+        if not self.doc_as_attr:
+            self.add_autosummary(relative_ref_paths=True)
 
 
 class CallableDataDocumenter(DataDocumenter):

--- a/tests/test-root/dummy.py
+++ b/tests/test-root/dummy.py
@@ -84,6 +84,14 @@ class TestClassWithInlineAutoClassSumm:
         pass
 
 
+class TestClassWithRefToOtherClass:
+    """Class test for the autodocsummary when a class attribute is a reference
+    to another class. No autosummary of the class should be generated for
+    the attribute. See also issue #69"""
+
+    foo = TestClass
+
+
 #: data to be skipped
 large_data = 'Should also be skipped'
 

--- a/tests/test-root/test_class_with_ref_to_other_class.rst
+++ b/tests/test-root/test_class_with_ref_to_other_class.rst
@@ -1,0 +1,6 @@
+Autoclasssumm of Dummy Class
+============================
+
+.. autoclass:: dummy.TestClassWithRefToOtherClass
+    :members:
+    :autosummary:

--- a/tests/test_autodocsumm.py
+++ b/tests/test_autodocsumm.py
@@ -322,6 +322,22 @@ class TestAutosummaryDocumenter:
 
         assert '()' not in html
 
+    def test_class_no_summary_for_reference_to_class(self, app):
+        # see also: issue #69
+        app.build()
+
+        html = get_html(app, 'test_class_with_ref_to_other_class.html')
+
+        # assert that the class itself has an autosummary that contains its
+        # attributes
+        assert in_autosummary("foo", html)
+
+        # Assert that there is no autosummary of the attribute that is an alias
+        # of another class. This autosummary would contain attrs/methods/...
+        # of the referenced class.
+        assert not in_autosummary("test_method", html)
+        assert not in_autosummary("test_attr", html)
+
     def test_inherited(self, app):
         app.build()
         html = get_html(app, 'test_inherited.html')


### PR DESCRIPTION
Closes #69

This is WIP for now, still needs tests. And I need to check if there aren't any unfortunate side effects. I'll have a look at how Sphinx itself detects an object as an "alias" because it clearly knows. Then I'll finalize this.