### PR TITLE
Autoexception support

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -75,31 +75,3 @@ jobs:
         "sphinxcontrib-jsmath<1.0.1"
         "sphinxcontrib-qthelp<1.0.7"
         "sphinxcontrib-serializinghtml<1.1.10"'
-
-
-  build-legacy-sphinx-30plus:
-    name: Build
-
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: [ "3.7", "3.8", "3.9" ]
-        sphinx-version: [
-          "3.0.*",  # possible range: 3.0.0 - 3.5.4
-        ]
-        include:
-          - python-version: "3.7"
-            sphinx-version: "3.5.*"  # latest version that supports py3.7
-    uses: ./.github/workflows/build.yml
-    with:
-      python-version: ${{ matrix.python-version }}
-      extra-requirements: '\
-        "sphinx==${{ matrix.sphinx-version }}"
-        "jinja2<3.1"
-        "alabaster<0.7.14"
-        "sphinxcontrib-applehelp<1.0.8"
-        "sphinxcontrib-devhelp<1.0.6"
-        "sphinxcontrib-htmlhelp<2.0.5"
-        "sphinxcontrib-jsmath<1.0.1"
-        "sphinxcontrib-qthelp<1.0.7"
-        "sphinxcontrib-serializinghtml<1.1.10"'

--- a/docs/conf_settings.rst
+++ b/docs/conf_settings.rst
@@ -78,6 +78,11 @@ Directives
     By default, this directives also sets the `:members:` option unless you
     specify `:no-members`.
 
+.. rst:directive:: autoexceptionsumm
+
+    The same as the ``autoclasssumm`` directive, just for an ``Exception`` 
+    subclass.
+
 .. rst:directive:: automodulesumm
 
     The same as the ``autoclasssumm`` directive, just for a module.

--- a/docs/demo_exception.rst
+++ b/docs/demo_exception.rst
@@ -1,0 +1,8 @@
+.. _demo_exception:
+
+Demo Exception
+==============
+
+.. autoexception:: dummy.MyException
+    :members:
+    :noindex:

--- a/docs/dummy.py
+++ b/docs/dummy.py
@@ -22,5 +22,18 @@ class MyClass(object):
     some_other_attr = None
 
 
+class MyException(object):
+    """Some Exception
+
+    With some description"""
+
+    def do_something_exceptional(self):
+        """Do something exceptional"""
+        pass
+
+    #: Any instance attribute
+    some_exception_attr = None
+
+
 #: Some module data
 large_data = 'Whatever'

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -8,6 +8,7 @@ Examples
 
     Demo Module <demo_module>
     Demo Class <demo_class>
+    Demo Exception <demo_exception>
     Demo Grouper <demo_grouper>
 
 Including a table of contents
@@ -24,11 +25,16 @@ The *autosummary* flag introduces a small table of contents. So::
 
 produces :ref:`this <demo_module>`. And::
 
-    .. autoclass:: dummy.SomeClass
+    .. autoclass:: dummy.MyClass
         :members:
         :autosummary:
 
-produces :ref:`this <demo_class>`.
+produces :ref:`this <demo_class>`, and for exceptions::
+
+    .. autoexception:: dummy.MyException
+        :members:
+        :autosummary:
+produces :ref:`this <demo_exception>`.
 
 By default, module members are (mainly) grouped according into *Functions*,
 *Classes* and *Data*, class members are grouped into *Methods* and
@@ -178,8 +184,8 @@ section of a class, you can specify::
 Multiple sections might be separated by `;;`, e.g.
 ``:autosummary-sections: Methods ;; Attributes``.
 
-This also works for the ``autoclasssumm`` and ``automodulesumm`` directives,
-e.g.::
+This also works for the ``autoclasssumm``, ``autoexceptionsumm`` and 
+``automodulesumm`` directives, e.g.::
 
     .. autoclasssumm:: dummy.SomeClass
         :autosummary-sections: Methods

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 
 requires-python = '>= 3.7'
 dependencies = [
-    'Sphinx >= 2.2, < 9.0',
+    'Sphinx >= 4.0, < 9.0',
 ]
 
 [project.urls]

--- a/tests/test-root/dummy.py
+++ b/tests/test-root/dummy.py
@@ -67,6 +67,18 @@ class TestClass(object):
     small_data = 'Should be skipped'
 
 
+class TestException(Exception):
+    """Exception test for autosummary"""
+
+    def __init__(self):
+        #: This is an exception attribute
+        self.exception_instance_attribute = 1
+
+    def test_exception_method(self):
+        """Test if the method is included"""
+        pass
+
+
 class InheritedTestClass(TestClass):
     """Class test for inherited attributes"""
 

--- a/tests/test-root/test_autoexceptionsumm.rst
+++ b/tests/test-root/test_autoexceptionsumm.rst
@@ -1,0 +1,4 @@
+Autoexceptionsumm of Dummy Exception
+====================================
+
+.. autoexceptionsumm:: dummy.TestException

--- a/tests/test-root/test_exception.rst
+++ b/tests/test-root/test_exception.rst
@@ -1,0 +1,4 @@
+Dummy Exception Doc
+===================
+
+.. autoexception:: dummy.TestException

--- a/tests/test_autodocsumm.py
+++ b/tests/test_autodocsumm.py
@@ -252,6 +252,17 @@ class TestAutosummaryDocumenter:
             'DummySection'
         )
 
+    def test_exception(self, app):
+        app.build()
+        html = get_html(app, 'test_exception.html')
+
+        if sphinx_version[:2] > [3, 1]:
+            assert in_autosummary("exception_instance_attribute", html)
+        elif sphinx_version[:2] < [3, 1]:
+            assert in_autosummary("TestException.exception_instance_attribute", html)
+
+        assert in_autosummary("test_exception_method", html)
+
     @pytest.mark.skipif(
         sphinx_version[:2] < [3, 1], reason="Only available for sphinx>=3"
     )
@@ -411,6 +422,19 @@ class TestAutoDocSummDirective:
         # test if the methods and attributes are there in a table
         assert in_autosummary("test_method", html)
         assert in_autosummary("test_attr", html)
+
+    def test_autoexceptionsumm(self, app):
+        """Test building the autosummary of a class."""
+        app.build()
+
+        html = get_html(app, 'test_autoexceptionsumm.html')
+
+        # the class docstring must not be in the html
+        assert "Class exception for autosummary" not in html
+
+        # test if the methods and attributes are there in a table
+        assert in_autosummary("test_exception_method", html)
+        assert in_autosummary("exception_instance_attribute", html)
 
     def test_autoclasssumm_no_titles(self, app):
         """Test building the autosummary of a class."""


### PR DESCRIPTION
this PR implements the support of the `autosummary` option for the `autoexception`-directive, and it adds the `autoexceptionsumm` directive (in analogy to the `autoclasssumm` and `automodsumm` directives)

closes #48